### PR TITLE
fix(deps): update winston-daily-rotate-file to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dateformat": "3.0.3",
     "signale": "1.4.0",
     "winston": "3.2.1",
-    "winston-daily-rotate-file": "3.8.0",
+    "winston-daily-rotate-file": "4.7.1",
     "winston-transport": "4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Old version has new semver vulnerabillity

Major version deprecations: https://github.com/winstonjs/winston-daily-rotate-file/releases/tag/v4.0.0 (no support voor winston 2)
Semver vulnerabillity: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw